### PR TITLE
Update action badges for project page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: page
 title: AddressBook Level-3
 ---
 
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
-[![codecov](https://codecov.io/gh/se-edu/addressbook-level3/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
+[![Java CI](https://github.com/AY2526S2-CS2103-F08-2/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2526S2-CS2103-F08-2/tp/actions/workflows/gradle.yml)
+[![codecov](https://codecov.io/gh/AY2526S2-CS2103-F08-2/tp/branch/master/graph/badge.svg)](https://codecov.io/gh/AY2526S2-CS2103-F08-2/tp)
 
 ![Ui](images/Ui.png)
 


### PR DESCRIPTION
Fixes #42 

Task A2

A2.
Update the link of the GitHub Actions build status badge (Build Status) so that it reflects the build status of your team repo.