### PR TITLE
Add ability to edit role in Edit command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -27,9 +27,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.person.Player;
 import seedu.address.model.person.Role;
-import seedu.address.model.person.Staff;
 import seedu.address.model.tag.Tag;
 
 /**


### PR DESCRIPTION
Closes #74 

## Summary
Add ability to change roles to player or staff via the Edit command. Role name is case insensitive.
Examples: `edit 1 r/player` or `edit 1 r/staff`