### PR TITLE
Preserve attendance when events are rebuilt during edit and delete flows

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EventEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EventEditCommand.java
@@ -124,8 +124,13 @@ public class EventEditCommand extends Command {
         }
 
         EventPlayerList eventPlayerList = new EventPlayerList(playerList);
+        Set<Person> attendedPlayers = eventToEdit.getAttendedPlayerList().asUnmodifiableObservableList().stream()
+                .filter(playerList::contains)
+                .collect(java.util.stream.Collectors.toSet());
+        EventPlayerList attendedPlayerList = new EventPlayerList(attendedPlayers);
 
-        return Event.createEvent(updatedName, updatedEventDate, updatedEventType, eventPlayerList);
+        return Event.createEventWithAttendees(updatedName, updatedEventDate, updatedEventType,
+                eventPlayerList, attendedPlayerList);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/EventEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EventEditCommandTest.java
@@ -22,9 +22,9 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.EventPlayerList;
-import seedu.address.testutil.TypicalPersons;
 import seedu.address.testutil.EditEventDescriptorBuilder;
 import seedu.address.testutil.EventBuilder;
+import seedu.address.testutil.TypicalPersons;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EventEditCommand.

--- a/src/test/java/seedu/address/logic/commands/EventEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EventEditCommandTest.java
@@ -15,11 +15,14 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EventEditCommand.EditEventDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.event.Event;
+import seedu.address.model.event.EventPlayerList;
+import seedu.address.testutil.TypicalPersons;
 import seedu.address.testutil.EditEventDescriptorBuilder;
 import seedu.address.testutil.EventBuilder;
 
@@ -52,6 +55,32 @@ public class EventEditCommandTest {
         String expectedMessage = EventEditCommand.MESSAGE_NO_FIELD_WAS_CHANGED;
 
         assertCommandFailure(eventEditCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_editMetadata_preservesAttendance() throws CommandException {
+        AddressBook addressBook = new AddressBook();
+        addressBook.addPerson(TypicalPersons.PLAYER_AMY);
+
+        Event baseEvent = new EventBuilder()
+                .withEventName("Warm Up")
+                .withEventType("TRAINING")
+                .withDate("2026-05-15 1600")
+                .withPlayers(java.util.Set.of(TypicalPersons.PLAYER_AMY))
+                .build();
+        Event eventWithAttendance = Event.createEventWithAttendees(baseEvent.getEventName(), baseEvent.getEventDate(),
+                baseEvent.getEventType(), baseEvent.getEventPlayerList(),
+                new EventPlayerList(java.util.Set.of(TypicalPersons.PLAYER_AMY)));
+        addressBook.addEvent(eventWithAttendance);
+
+        ModelManager model = new ModelManager(addressBook, new UserPrefs());
+        EditEventDescriptor descriptor = new EditEventDescriptorBuilder().withEventName("WarmUpUpdated").build();
+
+        new EventEditCommand(INDEX_FIRST_EVENT, descriptor).execute(model);
+
+        Event editedEvent = model.getEventList().get(0);
+        assertTrue(editedEvent.getAttendedPlayerList().contains(TypicalPersons.PLAYER_AMY));
+        assertEquals(TypicalPersons.PLAYER_AMY.getName().toString() + " : 100.0%\n", model.getAttendanceReport());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -11,11 +11,16 @@ import static seedu.address.testutil.TypicalPersons.PLAYER_BEN;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.EventPlayerList;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.testutil.EventBuilder;
 import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {
@@ -86,6 +91,32 @@ public class ModelManagerTest {
     public void hasPerson_personInAddressBook_returnsTrue() {
         modelManager.addPerson(PLAYER_AMY);
         assertTrue(modelManager.hasPerson(PLAYER_AMY));
+    }
+
+    @Test
+    public void deletePerson_playerInEvent_preservesOtherPlayersAttendance() throws CommandException {
+        AddressBook addressBook = new AddressBook();
+        addressBook.addPerson(PLAYER_AMY);
+        addressBook.addPerson(PLAYER_BEN);
+
+        Event baseEvent = new EventBuilder()
+                .withEventName("Team Training")
+                .withEventType("TRAINING")
+                .withDate("2025-01-10 1800")
+                .withPlayers(Set.of(PLAYER_AMY, PLAYER_BEN))
+                .build();
+        Event event = Event.createEventWithAttendees(baseEvent.getEventName(), baseEvent.getEventDate(),
+                baseEvent.getEventType(), baseEvent.getEventPlayerList(), new EventPlayerList(Set.of(PLAYER_BEN)));
+        addressBook.addEvent(event);
+
+        ModelManager model = new ModelManager(addressBook, new UserPrefs());
+        model.deletePerson(PLAYER_AMY);
+
+        Event updatedEvent = model.getEventList().get(0);
+        assertFalse(updatedEvent.getEventPlayerList().contains(PLAYER_AMY));
+        assertTrue(updatedEvent.getEventPlayerList().contains(PLAYER_BEN));
+        assertTrue(updatedEvent.getAttendedPlayerList().contains(PLAYER_BEN));
+        assertEquals(PLAYER_BEN.getName().toString() + " : 100.0%\n", model.getAttendanceReport());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -20,8 +20,8 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.EventPlayerList;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.testutil.EventBuilder;
 import seedu.address.testutil.AddressBookBuilder;
+import seedu.address.testutil.EventBuilder;
 
 public class ModelManagerTest {
 


### PR DESCRIPTION
## Summary
This PR fixes attendance data loss caused by event reconstruction during person deletion and event editing.

Previously, when an event was rebuilt through `EventEditCommand.createEditedEvent(...)`, the rebuilt event was created with a fresh empty attendance list. This caused existing attendance marks to be lost even when the remaining players were still valid members of the event.

This affected both:
- `eventedit` flows
- player deletion flows that internally rebuild affected events

## Fix
- Preserve existing attendance records when rebuilding an event
- Filter preserved attendance to only players who still remain in the edited event
- Keep attendance consistent after deleting a player from an event
- Keep attendance consistent after editing event metadata such as name/date/type

## Issues addressed
- Closes #251
- Closes #291

## Tests
Added regression coverage for:
- editing an event without losing valid attendance marks
- deleting one player from an event without clearing attendance for other players

## Notes
This PR only fixes attendance loss caused by event reconstruction.
It does not address the separate delete parser / filtered-list issues.