### PR TITLE
Fix documentation issues for attendance and event commands

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -801,13 +801,14 @@ otherwise)
 2. Manager provides the name of the training session, date, and players that attended the training.
 3. SoCcer Manager checks that the players exist in the address book.
 4. SoCcer Manager adds the training session with the specified name, date, and players.
+   Use case ends.
 
 **Extensions**
 
 * 2a. Manager provides an attribute.
     * 2a1. SoCcer Manager checks that the attribute exists.
-    * 2a2. SoCcer Manager finds all the players with the attribute.
-      Use case resumes at step 3.
+      * 2a2. SoCcer Manager gets a list of all the players with the specified attribute.
+        Use case resumes at step 4.
 
 ### Non-Functional Requirements
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -125,7 +125,7 @@ Examples:
 
 Adds a match to the address book.
 
-Format: `matchadd n/OPPONENT_NAME d/DATE [st/STATUS | pos/POSITION | tm/TEAM] [pl/PLAYER_NAME]…​`
+Format: `matchadd n/OPPONENT_NAME d/DATE [st/STATUS] [pos/POSITION] [tm/TEAM] [pl/PLAYER_NAME]…​`
 
 Notes: 
 - Date must have format `yyyy-MM-dd HHmm`
@@ -547,7 +547,7 @@ Furthermore, certain edits can cause SoCcer Manager to behave in unexpected ways
 | Action              | Format, Examples                                                                                                                                                                                                                      |
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Add**             | `add n/NAME r/ROLE p/PHONE_NUMBER e/EMAIL a/ADDRESS [tm/TEAM] [st/STATUS] [pos/POSITION] [t/TAG]…​` <br> e.g., `add n/James Ho r/staff p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 tm/First Team st/Active t/friend` |
-| **Match**           | `matchadd n/OPPONENT_NAME d/DATE [st/STATUS \| pos/POSITION \| tm/TEAM] [pl/PLAYER_NAME]…​` <br> e.g., `matchadd n/Mancherster United d/2026-05-15 1600 tm/First Team pl/John Doe`                                                    |
+| **Match**           | `matchadd n/OPPONENT_NAME d/DATE [st/STATUS] [pos/POSITION] [tm/TEAM] [pl/PLAYER_NAME]…​` <br> e.g., `matchadd n/Mancherster United d/2026-05-15 1600 tm/First Team pl/John Doe`                                                      |
 | **Training**        | `trainingadd n/TRAINING_NAME d/DATE [st/STATUS] [pos/POSITION] [tm/TEAM] [pl/PLAYER_NAME]…​` <br> e.g., `trainingadd n/Warm Up d/2026-06-16 1700 tm/First Team pl/John Doe`                                                           |
 | **Attendance**      | `attendance`                                                                                                                                                                                                                          |
 | **Attendance Mark** | `attendancemark INDEX [pl/PLAYER_NAME]…​` <br> e.g., `attendancemark 1 pl/Alex Yeoh pl/Bernice Yu`                                                                                                                                    |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -186,8 +186,10 @@ Notes:
 - The event index provided must be a valid index.
 - The players provided must exist in the addressbook and also be part of the event player list.
 - Players who are not present have (NP) beside their name in the event player list. Those who are present have (P) instead.
+- Warning: Attendance can only be marked currently. Once a player is marked for attendance, they cannot be unmarked. See [_Planned Enhancements_](DeveloperGuide.md#appendix-planned-enhancements)
 
-Examples:
+
+- Examples:
 - `attendancemark 1 pl/Alex Yeoh`
 - `attendancemark 2 pl/Alex Yeoh pl/Bernice Yu`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -141,7 +141,7 @@ Examples:
 
 Adds a training session to the address book.
 
-Format: `trainingadd n/TRAINING_NAME d/DATE [st/STATUS | pos/POSITION | tm/TEAM] [pl/PLAYER_NAME]…​`
+Format: `trainingadd n/TRAINING_NAME d/DATE [st/STATUS] [pos/POSITION] [tm/TEAM] [pl/PLAYER_NAME]…​`
 
 Notes:
 - Date must have format `yyyy-MM-dd HHmm`
@@ -546,7 +546,7 @@ Furthermore, certain edits can cause SoCcer Manager to behave in unexpected ways
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Add**             | `add n/NAME r/ROLE p/PHONE_NUMBER e/EMAIL a/ADDRESS [tm/TEAM] [st/STATUS] [pos/POSITION] [t/TAG]…​` <br> e.g., `add n/James Ho r/staff p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 tm/First Team st/Active t/friend` |
 | **Match**           | `matchadd n/OPPONENT_NAME d/DATE [st/STATUS \| pos/POSITION \| tm/TEAM] [pl/PLAYER_NAME]…​` <br> e.g., `matchadd n/Mancherster United d/2026-05-15 1600 tm/First Team pl/John Doe`                                                    |
-| **Training**        | `trainingadd n/TRAINING_NAME d/DATE [st/STATUS \| pos/POSITION \| tm/TEAM] [pl/PLAYER_NAME]…​` <br> e.g., `trainingadd n/Warm Up d/2026-06-16 1700 tm/First Team pl/John Doe`                                                         |
+| **Training**        | `trainingadd n/TRAINING_NAME d/DATE [st/STATUS] [pos/POSITION] [tm/TEAM] [pl/PLAYER_NAME]…​` <br> e.g., `trainingadd n/Warm Up d/2026-06-16 1700 tm/First Team pl/John Doe`                                                           |
 | **Attendance**      | `attendance`                                                                                                                                                                                                                          |
 | **Attendance Mark** | `attendancemark INDEX [pl/PLAYER_NAME]…​` <br> e.g., `attendancemark 1 pl/Alex Yeoh pl/Bernice Yu`                                                                                                                                    |
 | **Clear**           | `clear`                                                                                                                                                                                                                               |
@@ -557,8 +557,8 @@ Furthermore, certain edits can cause SoCcer Manager to behave in unexpected ways
 | **Edit Event**      | `eventedit INDEX [n/EVENT_NAME] [et/EVENT_TYPE] [d/DATE] [pl/PLAYER_NAME]…​`<br> e.g.,`eventedit 2 n/Barcelona et/MATCH pl/Alex Yeoh`                                                                                                 |
 | **Filter**          | `filter [r/ROLE] [tm/TEAM] [st/STATUS] [pos/POSITION] [goals/[><\|=]NUM] [wins/[>\|< \|=]NUM] [losses/[>\|<\|=]NUM]`<br> e.g., `filter r/player pos/Forward goals/>10`                                                                |
 | **Find**            | `find [r/ROLE] KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`, `find r/player James`, `find r/staff Alex`                                                                                                                       |
-| **List**            | `list` / `list r/ROLE` / `list [r/ROLE] [tm/TEAM] [st/STATUS] [pos/POSITION]`<br> e.g., `list r/player st/Active`                                                                                                                   |
-| **Sort**            | `sort by/ATTRIBUTE [desc]` / `sort r/player by/ATTRIBUTE [desc]` / `sort r/staff by/ATTRIBUTE [desc]`<br> e.g., `sort by/name desc`                                                                                                  |
+| **List**            | `list` / `list r/ROLE` / `list [r/ROLE] [tm/TEAM] [st/STATUS] [pos/POSITION]`<br> e.g., `list r/player st/Active`                                                                                                                     |
+| **Sort**            | `sort by/ATTRIBUTE [desc]` / `sort r/player by/ATTRIBUTE [desc]` / `sort r/staff by/ATTRIBUTE [desc]`<br> e.g., `sort by/name desc`                                                                                                   |
 | **Set**             | `set INDEX STAT VALUE` <br> e.g., `set 1 goals 6`                                                                                                                                                                                     |
 | **Update**          | `update INDEX STAT VALUE` <br> e.g., `update 1 wins 1`                                                                                                                                                                                |
 | **Help**            | `help`                                                                                                                                                                                                                                |

--- a/src/main/java/seedu/address/logic/commands/AttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AttendanceCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.event.EventType;
 import seedu.address.model.person.Role;
 
 /**
@@ -15,15 +14,15 @@ public class AttendanceCommand extends Command {
     public static final String COMMAND_WORD = "attendance";
 
     public static final String MESSAGE_SUCCESS = "=== Player Attendance Rates ===\n";
-    public static final String MESSAGE_NO_TRAINING = "No trainings detected!";
+    public static final String MESSAGE_NO_EVENT = "No events detected!";
     public static final String MESSAGE_NO_PLAYERS = "No players detected!";
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.getEventList().filtered(e -> e.getEventType() == EventType.TRAINING).isEmpty()) {
-            throw new CommandException(MESSAGE_NO_TRAINING);
+        if (model.getEventList().isEmpty()) {
+            throw new CommandException(MESSAGE_NO_EVENT);
         } else if (model.getAddressBook().getPersonList().filtered(p -> p.getRole() == Role.PLAYER).isEmpty()) {
             throw new CommandException(MESSAGE_NO_PLAYERS);
         }


### PR DESCRIPTION
Closes #312 , Closes #239 , Closes #256 , Closes #243 

### Summary
This PR fixes the following issues:

#312 Fixed vagueness in add new training use case (UC12) and corrected a wrong resumption step

#239 Added warning that user cannot reverse marking of attendance to `attendancemark` command in user guide

#256 Fixed inconsistent parameter notation for `trainingadd` and `matchadd` in user guide

#243 Inconsistent behavior of attendance command (ignoring matches when UG says it works for all events)