### PR TITLE
Fix person names to be case insensitive

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -108,6 +108,8 @@ A person can have any number of tags (including 0)
 
 Notes:
 * `tm/TEAM`, `st/STATUS`, and `pos/POSITION` are optional.
+* A person's name is case insensitive. If `Alex Yeoh` exists in SoCcer Manager, `alex yeoh` will not be allowed to be 
+added.
 * If omitted, defaults are used: `Unassigned Team`, `Unknown`, `Unassigned Position`.
 * If provided, `TEAM`/`STATUS`/`POSITION` must already exist in their respective catalogs
   (see [Attributes](#attributes)).

--- a/src/main/java/seedu/address/logic/commands/AttendanceMarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AttendanceMarkCommand.java
@@ -72,7 +72,7 @@ public class AttendanceMarkCommand extends Command {
 
         for (String s : playerNames) {
             Optional<Person> personToMark = model.getAddressBook().getPersonList().stream()
-                    .filter(p -> p.getName().fullName.equals(s))
+                    .filter(p -> p.getName().toString().equalsIgnoreCase(s))
                     .findFirst();
 
             if (personToMark.isPresent()) {

--- a/src/main/java/seedu/address/logic/commands/MatchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MatchCommand.java
@@ -141,7 +141,7 @@ public class MatchCommand extends Command {
             }
 
             Person person = model.getAddressBook().getPersonList().stream()
-                    .filter(p -> p.getName().toString().equals(playerName.trim()))
+                    .filter(p -> p.getName().toString().equalsIgnoreCase(playerName.trim()))
                     .findFirst()
                     .orElseThrow(() -> new CommandException(String.format(MESSAGE_PERSON_DOES_NOT_EXIST, playerName)));
 

--- a/src/main/java/seedu/address/logic/commands/TrainingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TrainingCommand.java
@@ -141,7 +141,7 @@ public class TrainingCommand extends Command {
             }
 
             Person person = model.getAddressBook().getPersonList().stream()
-                    .filter(p -> p.getName().toString().equals(playerName.trim()))
+                    .filter(p -> p.getName().toString().equalsIgnoreCase(playerName.trim()))
                     .findFirst()
                     .orElseThrow(() -> new CommandException(String.format(MESSAGE_PERSON_DOES_NOT_EXIST, playerName)));
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -56,7 +56,7 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+        return fullName.equalsIgnoreCase(otherName.fullName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -56,7 +56,7 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equalsIgnoreCase(otherName.fullName);
+        return fullName.trim().equalsIgnoreCase(otherName.fullName.trim());
     }
 
     @Override

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -44,7 +44,7 @@ public class PersonTest {
 
         // name differs in case, all other attributes same -> returns false
         Person editedBen = new PersonBuilder(PLAYER_BEN).withName(VALID_NAME_PLAYER_BEN.toLowerCase()).build();
-        assertFalse(PLAYER_BEN.isSamePerson(editedBen));
+        assertTrue(PLAYER_BEN.isSamePerson(editedBen));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_PLAYER_BEN + " ";

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -42,14 +42,9 @@ public class PersonTest {
         editedAmy = new PersonBuilder(PLAYER_AMY).withName(VALID_NAME_PLAYER_BEN).build();
         assertFalse(PLAYER_AMY.isSamePerson(editedAmy));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Person editedBen = new PersonBuilder(PLAYER_BEN).withName(VALID_NAME_PLAYER_BEN.toLowerCase()).build();
         assertTrue(PLAYER_BEN.isSamePerson(editedBen));
-
-        // name has trailing spaces, all other attributes same -> returns false
-        String nameWithTrailingSpaces = VALID_NAME_PLAYER_BEN + " ";
-        editedBen = new PersonBuilder(PLAYER_BEN).withName(nameWithTrailingSpaces).build();
-        assertFalse(PLAYER_BEN.isSamePerson(editedBen));
     }
 
     @Test


### PR DESCRIPTION
Closes #310 and #234

Person names are now case insensitive. All commands which require person names should ignore casing